### PR TITLE
Enhancement: coffeelint.json ignores backticks

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -2,7 +2,9 @@
   "no_trailing_whitespace" : {
     "level" : "error"
   },
-
+  "no_backticks": {
+    "level": "ignore"
+  },
   "max_line_length" : {
     "value": 120,
     "level" : "error"


### PR DESCRIPTION
This will help with coffee linting errors when dealing with ES6 modules.
