### PR TITLE
Add Ctrl-j/k bindings to tig

### DIFF
--- a/tigrc
+++ b/tigrc
@@ -1,2 +1,4 @@
 bind status D !@?rm %(file)
 set vertical-split = no
+bind diff <Ctrl-j> next
+bind diff <Ctrl-k> previous


### PR DESCRIPTION
In the log/diff view (the log is open and showing the diff for the highlighted commit), now you can move up and down commits with Ctrl-j/k, just like you can navigate up and down in vim buffers.
