### PR TITLE
Replace Startify buffer when opening file

### DIFF
--- a/vim/plugin-configs/vim-startify.vim
+++ b/vim/plugin-configs/vim-startify.vim
@@ -43,6 +43,8 @@ let g:startify_show_files = 1
 let g:startify_show_files_number = 10
 " A list of files to bookmark. Always shown
 let g:startify_bookmarks = [ '~/.vimrc' ]
+" Replace startify buffer when opening file from vimfiler
+autocmd User Startified setlocal buftype=
 
 "===============================================================================
 " Plugin Keymappings


### PR DESCRIPTION
I tried this out based on your recommendation and it seemed to work. I think this is a good addition to the base dotfiles rather than my custom configuration since this will make Startify behave consistently across Unite and Vimfiler.
