### PR TITLE
Bug Fix: Allow `<Space>tr` to toggle vimfiler

### DIFF
--- a/vim/plugin-configs/vimfiler.vim
+++ b/vim/plugin-configs/vimfiler.vim
@@ -40,6 +40,7 @@ let g:vimfiler_time_format = '%m-%d-%y %H:%M:%S'
 let g:vimfiler_expand_jump_to_first_child = 0
 let g:vimfiler_ignore_pattern = '\.git\|\.DS_Store\|\.pyc'
 
+autocmd FileType vimfiler nunmap <buffer> <Space>
 autocmd FileType vimfiler nunmap <buffer> <C-l>
 autocmd FileType vimfiler nunmap <buffer> <C-j>
 autocmd FileType vimfiler nunmap <buffer> l


### PR DESCRIPTION
This seems to fix that pesky bug of having vimfiler try to rename a file when you're trying to toggle vimfiler closed. I have this in my custom config now, but I thought it might be worthy of adding to the master dotfiles.