### PR TITLE
Alias `vi` to launch `vim`

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -213,6 +213,7 @@ alias tmuxp='tmux attach -t pair-session || tmux new-session -t host-session -s 
 alias delete_pyc='find . -name \*.pyc -exec rm \{\} \+'
 alias c='clear'
 alias vom='vim'
+alias vi='vim'
 alias cljs='planck'
 # >>1
 


### PR DESCRIPTION
Once in awhile I will accidentally type `vi` rather than `vim`. I cannot think of a reason that I would actually need to use `vi`.