### PR TITLE
Change cursor shape in vim between modes

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -81,3 +81,10 @@ filetype plugin indent on
 " Source Vim configurations {1
 call ProcessList(b:fileList, "SourceFile")
 " }1
+
+
+" Change cursor shape between insert and normal mode in iTerm2.app
+if $TERM_PROGRAM =~ "iTerm"
+    let &t_SI = "\<Esc>]50;CursorShape=1\x7" " Vertical bar in insert mode
+    let &t_EI = "\<Esc>]50;CursorShape=0\x7" " Block in normal mode
+endif


### PR DESCRIPTION
Change from block (normal) to pipe (insert) cursor in vim.  Pipe cursor also fits between characters, showing exactly where action will occur.