### PR TITLE
Support for copy/paste (tmux and vim) in Sierra

### DIFF
--- a/install-scripts/OSX/install-packages.sh
+++ b/install-scripts/OSX/install-packages.sh
@@ -20,6 +20,7 @@ if [[ $answer != "n" ]] && [[ $answer != "N" ]] ; then
     brew install tig
     brew install aspell
     brew install node
+    brew install reattach-to-user-namespace --wrap-pbcopy-and-pbpaste
     brew install ack
     brew install tmux
     brew install the_silver_searcher

--- a/mac-tmux/tmux.conf
+++ b/mac-tmux/tmux.conf
@@ -70,3 +70,6 @@ bind -n C-h run "$is_view_vim_diff && tmux send-keys C-h || tmux select-pane -L"
 bind -n C-j run "$is_view_vim_diff && tmux send-keys C-j || tmux select-pane -D"
 bind -n C-k run "$is_view_vim_diff && tmux send-keys C-k || tmux select-pane -U"
 bind -n C-l run "$is_view_vim_diff && tmux send-keys C-l || tmux select-pane -R"
+
+# Add support for copy paste when using Sierra
+set-option -g default-command "reattach-to-user-namespace -l zsh"


### PR DESCRIPTION
With the upgrade to MacOS Sierra it seems reattach-to-user-namespace is once again required :)