### PR TITLE
[UPDATE]: remove unsupport args from reattach-to-user-namespace

### DIFF
--- a/install-scripts/OSX/install-packages.sh
+++ b/install-scripts/OSX/install-packages.sh
@@ -20,7 +20,7 @@ if [[ $answer != "n" ]] && [[ $answer != "N" ]] ; then
     brew install tig
     brew install aspell
     brew install node
-    brew install reattach-to-user-namespace --wrap-pbcopy-and-pbpaste
+    brew install reattach-to-user-namespace
     brew install tmux
     brew install the_silver_searcher
     brew install planck


### PR DESCRIPTION
Update for the latest reattach-to-user-namespace