### PR TITLE
Update tmux vi commands for tmux v2.5

### DIFF
--- a/mac-tmux/tmux.conf
+++ b/mac-tmux/tmux.conf
@@ -30,9 +30,9 @@ setw -g aggressive-resize on
 # -----------------------------------------------------------------------------
 bind Space copy-mode
 bind C-Space copy-mode
-bind -t vi-copy v begin-selection
-bind -t vi-copy y copy-pipe "pbcopy"
-bind -t vi-copy Escape cancel
+bind-key -Tcopy-mode-vi 'v' send -X begin-selection
+bind-key -Tcopy-mode-vi 'y' send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+bind-key -Tcopy-mode-vi Escape send -X cancel
 
 # -----------------------------------------------------------------------------
 # After we have something yanked back in Vim we can paste our yanked selection


### PR DESCRIPTION
The previous commands error out when running tmux v2.5 - these new commands work as expected