### PR TITLE
Don't overwrite custom GOPATHs

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -221,7 +221,10 @@ source /usr/local/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 # >>1
 
 # Export Go Path <<1
-export GOPATH=~/Projects/go
+if [[ ! -n $GOPATH ]]; then
+    export GOPATH=~/Projects/go
+fi
+
 export PATH=$PATH:$GOPATH/bin
 # >>1
 


### PR DESCRIPTION
If the user defines their own GOPATH in one of their Custom Configurations, respect that GOPATH.